### PR TITLE
non-boolean-like argument following long bool opt without '=' should be considered as an argument, not an erroneous value

### DIFF
--- a/src/Cli.php
+++ b/src/Cli.php
@@ -67,7 +67,7 @@ class Cli {
 
     /**
      * Breaks a cell into several lines according to a given width.
-     * 
+     *
      * @param string $text The text of the cell.
      * @param int $width The width of the cell.
      * @param bool $addSpaces Whether or not to right-pad the cell with spaces.
@@ -364,9 +364,9 @@ class Cli {
                     $key = $parts[0];
 
                     // Does not have an =, so choose the next arg as its value,
-                    // unless it is defined as 'bool' in which case there is no
+                    // unless it is defined as 'boolean' in which case there is no
                     // value to seek in next arg
-                    if ((!isset($types[$str]) || (isset($types[$str]) && $types[$str] != 'bool')) &&
+                    if ( (Cli::val($key, $types) != 'boolean') &&
                         count($parts) == 1 && isset($argv[$i + 1]) && preg_match('/^--?.+/', $argv[$i + 1]) == 0) {
                         $v = $argv[$i + 1];
                         $i++;

--- a/src/Cli.php
+++ b/src/Cli.php
@@ -363,8 +363,11 @@ class Cli {
                     $parts = explode('=', $str);
                     $key = $parts[0];
 
-                    // Does not have an =, so choose the next arg as its value
-                    if (count($parts) == 1 && isset($argv[$i + 1]) && preg_match('/^--?.+/', $argv[$i + 1]) == 0) {
+                    // Does not have an =, so choose the next arg as its value,
+                    // unless it is defined as 'bool' in which case there is no
+                    // value to seek in next arg
+                    if ((!isset($types[$str]) || (isset($types[$str]) && $types[$str] != 'bool')) &&
+                        count($parts) == 1 && isset($argv[$i + 1]) && preg_match('/^--?.+/', $argv[$i + 1]) == 0) {
                         $v = $argv[$i + 1];
                         $i++;
                     } elseif (count($parts) == 2) {// Has a =, so pick the second piece

--- a/src/Cli.php
+++ b/src/Cli.php
@@ -366,10 +366,21 @@ class Cli {
                     // Does not have an =, so choose the next arg as its value,
                     // unless it is defined as 'boolean' in which case there is no
                     // value to seek in next arg
-                    if ( (Cli::val($key, $types) != 'boolean') &&
-                        count($parts) == 1 && isset($argv[$i + 1]) && preg_match('/^--?.+/', $argv[$i + 1]) == 0) {
+                    if (count($parts) == 1 && isset($argv[$i + 1]) && preg_match('/^--?.+/', $argv[$i + 1]) == 0) {
                         $v = $argv[$i + 1];
-                        $i++;
+                        if(Cli::val($key, $types) == 'boolean') {
+                            if (in_array($v, ['0', '1', 'true', 'false', 'on', 'off', 'yes', 'no'])) {
+                              // The next arg looks like a boolean to me.
+                              $i++;
+                            }
+                            else {
+                              // Next arg is not a boolean: set the flag on, and use next arg in its own iteration
+                              $v = true;
+                            }
+                        }
+                        else {
+                            $i++;
+                        }
                     } elseif (count($parts) == 2) {// Has a =, so pick the second piece
                         $v = $parts[1];
                     } else {


### PR DESCRIPTION
Consider the following, where "opt" is a long boolean option:
script --opt true  => gives opt: true
script --opt filename  => gave an error. I want it to give: opt: true, and first arg=filename.
