### PR TITLE
Add a way to get registered commands

### DIFF
--- a/src/Cli.php
+++ b/src/Cli.php
@@ -246,6 +246,15 @@ class Cli {
             return false;
         }
     }
+    
+    /**
+     * Returns all available commands.
+     *
+     * @return string[] Returns the available commands as an array.
+     */
+    public function getCommands() {
+        return array_filter(array_keys($this->commandSchemas), array("self", "isCommand"));
+    }
 
     /**
      * Determines whether a command has options.


### PR DESCRIPTION
Currently there is no way to get the commands registered by the `CLI::command()` method.