### PR TITLE
parameter whit multiple arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ class App extends Garden\Cli\Application\CliApplication {
         $this->addFactory(\PDO::class, [\Garden\Cli\Utility\DbUtils::class, 'createMySQL']);
     }
 
-    protected function configureContainer(): void {
-        parent::configureContainer();
+    protected function configureContainer(Container $container): void {
+        parent::configureContainer($container);
 
         // Configure the container here.
     }

--- a/src/Application/CliApplication.php
+++ b/src/Application/CliApplication.php
@@ -72,8 +72,9 @@ class CliApplication extends Cli {
      */
     final public function getContainer(): Container {
         if ($this->container === null) {
-            $this->container = $this->createContainer();
-            $this->configureContainer();
+            $container = $this->createContainer();
+            $this->configureContainer($container);
+            $this->container = $container;
             $this->container->setInstance(Container::class, $this->container);
         }
         return $this->container;
@@ -93,8 +94,10 @@ class CliApplication extends Cli {
 
     /**
      * Configure the Container for usage.
+     *
+     * @param Container $container
      */
-    protected function configureContainer(): void {
+    protected function configureContainer(Container $container): void {
     }
 
     /**
@@ -233,7 +236,7 @@ class CliApplication extends Cli {
         $this
             ->command($options[self::OPT_COMMAND])
             ->description($description)
-            ->meta(self::META_ACTION, $method->getDeclaringClass()->getName() . '::' . $method->getName());
+            ->meta(self::META_ACTION, $class->getName() . '::' . $method->getName());
         $this->addParams($method);
 
         if ($options[self::OPT_SETTERS]) {
@@ -258,7 +261,7 @@ class CliApplication extends Cli {
      * @param array $options Options to control the behavior of the mapping.
      * @return $this
      */
-    public function addCommandClass(string $className, string $methodName, array $options = []): self {
+    public function addCommandClass(string $className, string $methodName = 'run', array $options = []): self {
         $options += [
             self::OPT_COMMAND => null,
             self::OPT_SETTERS => true,

--- a/tests/App/CliApplicationTest.php
+++ b/tests/App/CliApplicationTest.php
@@ -12,6 +12,7 @@ use Garden\Cli\Args;
 use Garden\Cli\Tests\AbstractCliTest;
 use Garden\Cli\Tests\Fixtures\Application;
 use Garden\Cli\Tests\Fixtures\Db;
+use Garden\Cli\Tests\Fixtures\RealCommand;
 use Garden\Cli\Tests\Fixtures\TestApplication;
 use Garden\Cli\Tests\Fixtures\TestCommands;
 
@@ -135,6 +136,13 @@ class CliApplicationTest extends AbstractCliTest {
         $this->assertTrue($schema->hasOpt('an-orange'));
 
         $this->assertTrue($schema->hasOpt('bar'));
+    }
+
+    public function testAddCommandSubclass(): void {
+        $this->app->addCommandClass(RealCommand::class, 'noParams');
+        $schema = $this->app->getSchema('real');
+
+        $this->assertSame(RealCommand::class.'::noParams', $schema->getMeta(CliApplication::META_ACTION));
     }
 
     /**

--- a/tests/Fixtures/RealCommand.php
+++ b/tests/Fixtures/RealCommand.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Cli\Tests\Fixtures;
+
+
+/**
+ * Do something real.
+ */
+class RealCommand extends TestCommands {
+
+}

--- a/tests/Fixtures/TestApplication.php
+++ b/tests/Fixtures/TestApplication.php
@@ -13,10 +13,10 @@ use Garden\Container\Container;
 use Garden\Container\Reference;
 
 class TestApplication extends CliApplication {
-    protected function configureContainer(): void {
-        parent::configureContainer();
+    protected function configureContainer(Container $container): void {
+        parent::configureContainer($container);
 
-        $this->getContainer()
+        $container
             ->rule(TestCommands::class)
             ->setShared(true)
             ->addCall('setDb', [new Reference(Db::class)]);


### PR DESCRIPTION
There is a way to make a parameter accept multiple arguments?
Example:
`
        $cli->arg(
            'SINGLE', 
            ''...,' 
            true
        );
        $cli->arg(
            'MULTIPLE', 
            ''...,' 
            true.
            true // multiple
        );
`
Usage:
`
$ mycopy source target1 target2 target3....
`