### PR TITLE
49 - add explicit nullable declarations

### DIFF
--- a/src/Cli.php
+++ b/src/Cli.php
@@ -978,7 +978,7 @@ class Cli
         &$value,
         string $type,
         string $name = "",
-        OptSchema $def = null
+        ?OptSchema $def = null
     ): bool {
         if ($def !== null && $def->isArray()) {
             $value = (array) $value;

--- a/src/Cli.php
+++ b/src/Cli.php
@@ -320,7 +320,7 @@ class Cli
      *
      * @throws Exception Throws an exception when {@link $exit} is false and the help or errors need to be displayed.
      */
-    public function parse(array $argv = null, bool $exit = true): Args
+    public function parse(?array $argv = null, bool $exit = true): Args
     {
         $formatOutputBak = $this->formatOutput;
         // Only format commands if we are exiting.


### PR DESCRIPTION
This should address #49 by adding the following explicit nullable declarations:

1. `Cli::parse`: `$argv`
2. `Cli::validateType` `$def`

The underlying issue is not visible when testing with PHP 8.4 and PHPUnit 8, so there is no clear difference when running the test suite.

However, when testing from an external project with PHP 8.4 and PHPUnit 12, two deprecation notices appear before the change and disappear after the change.